### PR TITLE
Set xmltask encoding to utf8

### DIFF
--- a/src/main/resources/fox/jason/prismjs/antlib.xml
+++ b/src/main/resources/fox/jason/prismjs/antlib.xml
@@ -159,7 +159,7 @@
       <prismjs-append-lang unless:blank="${lang}" lang="${lang}" known="lang.known"/>
       <prismjs if:set="lang.known" xtrc="@{xtrc}" xtrf="@{xtrf}" name="@{name}" class="@{class}" text="@{text}" outputclass="${lang}" highlighted="highlighted" count="@{count}" xml="@{xml}"/>
 
-      <xmltask if:set="lang.known" outputter="default" indent="false" source="@{source}" dest="${source}">
+      <xmltask if:set="lang.known" outputter="default" encoding="UTF-8" indent="false" source="@{source}" dest="${source}">
         <replace path="//*[@xtrc='@{xtrc}']" withXml="${highlighted}"/>
         <attr path="//*[@xtrc='@{xtrc}']" attr="outputclass" value="language-${lang}"/>
       </xmltask>


### PR DESCRIPTION
It seems that when processing topics with different encoding, it throws an exception:
`Error: java.lang.RuntimeException: Failed to parse 2e3df990028e185cfc03aee8ccd91db524309d8b.xml: path\to\2e3df990028e185cfc03aee8ccd91db524309d8b.xml`
`Line 11:Invalid byte 1 of 1-byte UTF-8 sequence.`

But setting the encoding to utf8 has fixed it.